### PR TITLE
Handle multiple scheduled blocks without fast paths

### DIFF
--- a/test_new/prompt_parser_patched_superhybrid_2.8_1.2(вернул обычные and).py
+++ b/test_new/prompt_parser_patched_superhybrid_2.8_1.2(вернул обычные and).py
@@ -408,6 +408,43 @@ def _parse_lark_cached(prompt: str):
     return schedule_parser.parse(prompt)
 # ----------------------------
 # ──────────────────────────────────────────────────────────────────────────────
+# Вспомогательные проверки для отключения fast-path
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _has_multiple_bracket_blocks(text: str) -> bool:
+    """Подсчитать количество верхнеуровневых блоков [...].
+
+    Используем стек глубины и игнорируем экранированные скобки, чтобы
+    не ошибиться на \[ \] и вложенных конструкциях. Возвращаем True,
+    если обнаружено два и более блока – в этом случае fast-path'ы
+    должны быть отключены и управление передано полноценному парсеру.
+    """
+
+    depth = 0
+    blocks = 0
+    escaped = False
+
+    for ch in text:
+        if escaped:
+            escaped = False
+            continue
+
+        if ch == "\\":
+            escaped = True
+            continue
+
+        if ch == "[":
+            depth += 1
+            if depth == 1:
+                blocks += 1
+        elif ch == "]" and depth > 0:
+            depth -= 1
+
+        if blocks > 1:
+            return True
+
+    return False
+# ──────────────────────────────────────────────────────────────────────────────
 # Общие вспомогалки для fast-path "[...]:N" (и CollectSteps, и get_schedule)
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -940,9 +977,18 @@ class CollectSteps(lark.Visitor):
         self.rng = random.Random(seed) if seed is not None else random
         self.schedules = []
 
+    # Явно обрабатываем корень, используя общий мерджер
+    def visit_start(self, tree):
+        return self._default_visit(tree)
+
     # — fast-path для "[...]:N [reverse]" на уровне prompt
     def visit_prompt(self, tree):
         full = resolve_tree(tree, keep_spacing=True)
+
+        # Если в строке несколько независимых блоков [...], отключаем fast-path и
+        # отдаём разбору/мерджеру по дереву, чтобы не потерять расписания.
+        if _has_multiple_bracket_blocks(full):
+            return self._default_visit(tree)
         # (A) Диапазоны после числа: "[a:b]:10 1-4,6-8 [reverse]"
         m_res = _extract_after_with_ranges(full, self.steps)
         if m_res and '|' not in full:
@@ -1702,6 +1748,9 @@ def _get_schedule_impl(prompt: str, steps: int, use_scheduling: bool, seed: int 
     # Литеральные \n и \t → реальные
     if "\\n" in prompt or "\\t" in prompt:
         prompt = prompt.replace("\\n", "\n").replace("\\t", "\t")
+
+    # Несколько независимых блоков [...] → отключаем fast-path и сразу идём в Lark
+    multiple_bracket_blocks = _has_multiple_bracket_blocks(prompt)
         
     # ── Быстрые пути ──────────────────────────────────────────────────────────
 
@@ -1761,80 +1810,81 @@ def _get_schedule_impl(prompt: str, steps: int, use_scheduling: bool, seed: int 
         return [[steps, _apply_and(_collapse_spaces(', '.join(chosen)))]]
 
 
-    # Явные диапазоны: "[...]:N a-b,c-d [r]" — ДОЛЖНЫ идти ПЕРЕД общим "[...]:N"
-    m_res = _extract_after_with_ranges(prompt, steps)
-    if m_res:
-        prompts, ranges, rev_flag, _first_is_percent = m_res
-        if rev_flag:
-            prompts = list(reversed(prompts))
-        schedules = []
+    if not multiple_bracket_blocks:
+        # Явные диапазоны: "[...]:N a-b,c-d [r]" — ДОЛЖНЫ идти ПЕРЕД общим "[...]:N"
+        m_res = _extract_after_with_ranges(prompt, steps)
+        if m_res:
+            prompts, ranges, rev_flag, _first_is_percent = m_res
+            if rev_flag:
+                prompts = list(reversed(prompts))
+            schedules = []
 
-        if ranges and ranges[0][0] > 1:
-            schedules.append([ranges[0][0] - 1, ""])
-        for i, (start, end) in enumerate(ranges[:len(prompts)]):
-            schedules.append([min(end, steps), prompts[i]])
-        if ranges and ranges[-1][1] < steps and prompts:
-            schedules.append([steps, prompts[-1]])
-        return [[e, _apply_and(_collapse_spaces(t))] for e, t in schedules]
+            if ranges and ranges[0][0] > 1:
+                schedules.append([ranges[0][0] - 1, ""])
+            for i, (start, end) in enumerate(ranges[:len(prompts)]):
+                schedules.append([min(end, steps), prompts[i]])
+            if ranges and ranges[-1][1] < steps and prompts:
+                schedules.append([steps, prompts[-1]])
+            return [[e, _apply_and(_collapse_spaces(t))] for e, t in schedules]
 
-    # НОВЫЙ fast-path: "[...:N]" (число/доля *внутри* скобок)
-    # Заменили точки на [^\[\]], чтобы не жадничать и не переполнять стек
-    m_inner = _re.match(r'(?s)^([^\[\]]*)\[([^\[\]]+)\]([^\[\]]*)$', prompt)
-    if m_inner and prompt.count('[') == 1 and prompt.count(']') == 1:
-        pre, inner, post = m_inner.groups()
-        # не конфликтуем со сложными конструкциями
-        # В этом fast-path нас интересует сложность ТОЛЬКО внутри inner.
-        if not _needs_complex_parse(inner or "", inner or ""):
-            parts = _split_top_level_colon_keep_empty(inner)
-            if len(parts) >= 2 and RE_NUMERIC_FULL.fullmatch(parts[-1]):
+        # НОВЫЙ fast-path: "[...:N]" (число/доля *внутри* скобок)
+        # Заменили точки на [^\[\]], чтобы не жадничать и не переполнять стек
+        m_inner = _re.match(r'(?s)^([^\[\]]*)\[([^\[\]]+)\]([^\[\]]*)$', prompt)
+        if m_inner and prompt.count('[') == 1 and prompt.count(']') == 1:
+            pre, inner, post = m_inner.groups()
+            # не конфликтуем со сложными конструкциями
+            # В этом fast-path нас интересует сложность ТОЛЬКО внутри inner.
+            if not _needs_complex_parse(inner or "", inner or ""):
+                parts = _split_top_level_colon_keep_empty(inner)
+                if len(parts) >= 2 and RE_NUMERIC_FULL.fullmatch(parts[-1]):
+                    try:
+                        boundary_f = float(parts[-1])
+                    except Exception:
+                        boundary_f = None
+                    if boundary_f is not None:
+                        prompts = [_unescape_literals(p.strip()) for p in parts[:-1]]
+                        # reverse в постфиксе (как префиксный токен)
+                        mrev = RE_REVERSE_PREFIX.match(post or "")
+                        rev_flag = bool(mrev)
+                        if mrev:
+                            post = (post or "")[mrev.end():]
+                        if rev_flag and not (pre.strip() or post.strip()):
+                            prompts = list(reversed(prompts))
+                        boundary = _to_end_step(boundary_f, steps)
+                        schedules = _build_bracket_inner_schedules(pre, prompts, boundary, post, steps)
+                        return [[e, _apply_and(_collapse_spaces(t))] for e, t in schedules]
+
+        # "[...]:N" с префиксом/суффиксом — общий случай
+        m_with_pre = RE_BRACKET_AFTER.match(prompt)
+        if m_with_pre and prompt.count('[') == 1 and prompt.count(']') == 1:
+            pre, inner, boundary_txt = m_with_pre.group(1), m_with_pre.group(2), m_with_pre.group(3)
+            rev_token = m_with_pre.group('rev')
+            post = m_with_pre.group('post') or ""
+            # Если в post есть явные диапазоны (например "6-8" или "10%-40%") — отдаем грамматике,
+            # иначе fast-path сломает семантику.
+            if _re.search(r'\b\d+%?\s*-\s*\d+%?', post):
+                pass  # не возвращаем — ниже сработает общий парсер
+            elif _needs_complex_parse(inner or "", prompt):
+                pass  # отдаём грамматике/Visitor
+            else:
                 try:
-                    boundary_f = float(parts[-1])
-                except Exception:
-                    boundary_f = None
-                if boundary_f is not None:
-                    prompts = [_unescape_literals(p.strip()) for p in parts[:-1]]
-                    # reverse в постфиксе (как префиксный токен)
-                    mrev = RE_REVERSE_PREFIX.match(post or "")
-                    rev_flag = bool(mrev)
-                    if mrev:
-                        post = (post or "")[mrev.end():]
-                    if rev_flag and not (pre.strip() or post.strip()):
-                        prompts = list(reversed(prompts))
-                    boundary = _to_end_step(boundary_f, steps)
-                    schedules = _build_bracket_inner_schedules(pre, prompts, boundary, post, steps)
+                    boundary = _to_end_step(float(boundary_txt), steps)
+                    inner_prompts = [_unescape_literals(p.strip()) for p in _split_top_level_colon_keep_empty(inner)]
+
+                    # reverse мог прийти отдельным токеном ИЛИ как начало post (префикс)
+                    m_rev = RE_REVERSE_PREFIX.match(post or "")
+                    rev_here = bool(rev_token) or bool(m_rev)
+                    if m_rev:
+                        post = (post or "")[m_rev.end():]
+
+                    # Реверс ТОЛЬКО для «чистой» формы (без префикса/суффикса)
+                    if rev_here and not ((pre or "").strip() or (post or "").strip()):
+                        inner_prompts = list(reversed(inner_prompts))
+
+                    schedules = _build_bracket_after_schedules(pre, inner_prompts, boundary, post, steps)
                     return [[e, _apply_and(_collapse_spaces(t))] for e, t in schedules]
-
-    # "[...]:N" с префиксом/суффиксом — общий случай
-    m_with_pre = RE_BRACKET_AFTER.match(prompt)
-    if m_with_pre and prompt.count('[') == 1 and prompt.count(']') == 1:
-        pre, inner, boundary_txt = m_with_pre.group(1), m_with_pre.group(2), m_with_pre.group(3)
-        rev_token = m_with_pre.group('rev')
-        post = m_with_pre.group('post') or ""
-        # Если в post есть явные диапазоны (например "6-8" или "10%-40%") — отдаем грамматике,
-        # иначе fast-path сломает семантику.
-        if _re.search(r'\b\d+%?\s*-\s*\d+%?', post):
-            pass  # не возвращаем — ниже сработает общий парсер
-        elif _needs_complex_parse(inner or "", prompt):
-            pass  # отдаём грамматике/Visitor
-        else:
-            try:
-                boundary = _to_end_step(float(boundary_txt), steps)
-                inner_prompts = [_unescape_literals(p.strip()) for p in _split_top_level_colon_keep_empty(inner)]
-
-                # reverse мог прийти отдельным токеном ИЛИ как начало post (префикс)
-                m_rev = RE_REVERSE_PREFIX.match(post or "")
-                rev_here = bool(rev_token) or bool(m_rev)
-                if m_rev:
-                    post = (post or "")[m_rev.end():]
-
-                # Реверс ТОЛЬКО для «чистой» формы (без префикса/суффикса)
-                if rev_here and not ((pre or "").strip() or (post or "").strip()):
-                    inner_prompts = list(reversed(inner_prompts))
-
-                schedules = _build_bracket_after_schedules(pre, inner_prompts, boundary, post, steps)
-                return [[e, _apply_and(_collapse_spaces(t))] for e, t in schedules]
-            except Exception:
-                pass
+                except Exception:
+                    pass
 
 
     # ── Обычный разбор ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add detection of multiple bracketed schedule blocks to bypass regex fast paths
- ensure CollectSteps merges timelines from the full parse tree, including the start node
- route complex prompts directly through the Lark parser to correctly combine multiple schedules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935197bc2a8832f8338841f7be4def7)